### PR TITLE
fix: Replace all config('app.name') with companyName() helper

### DIFF
--- a/app/Console/Commands/ReactivatePaidCustomers.php
+++ b/app/Console/Commands/ReactivatePaidCustomers.php
@@ -67,7 +67,7 @@ class ReactivatePaidCustomers extends Command
                             $message = "Halo {$customer->name},\n\n";
                             $message .= "Terima kasih atas pembayaran Anda. Layanan internet Anda telah diaktifkan kembali.\n\n";
                             $message .= "Selamat menikmati layanan kami!\n\n";
-                            $message .= "- Tim " . config('app.name');
+                            $message .= "- Tim " . companyName();
 
                             $result = $this->whatsapp->sendMessage($customer->phone, $message);
                             if ($result['success'] ?? false) {

--- a/app/Http/Controllers/Admin/InvoiceController.php
+++ b/app/Http/Controllers/Admin/InvoiceController.php
@@ -229,7 +229,7 @@ class InvoiceController extends Controller
         $message .= "🔗 *Link Pembayaran:*\n{$paymentResult['payment_url']}\n\n";
         $message .= "Link ini berlaku selama 24 jam.\n\n";
         $message .= "Terima kasih,\n";
-        $message .= "*" . config('app.name') . "*";
+        $message .= "*" . companyName() . "*";
 
         $waResult = $this->whatsapp->send($customer->phone, $message);
 

--- a/app/Http/Controllers/Admin/OrderController.php
+++ b/app/Http/Controllers/Admin/OrderController.php
@@ -96,7 +96,7 @@ class OrderController extends Controller
             $message .= "Halo *{$order->customer_name}*,\n\n";
             $message .= "Pembayaran untuk pesanan *{$order->order_number}* telah dikonfirmasi.\n\n";
             $message .= "Tim kami akan segera menghubungi Anda untuk jadwal pemasangan.\n\n";
-            $message .= "Terima kasih!\n*" . config('app.name') . "*";
+            $message .= "Terima kasih!\n*" . companyName() . "*";
 
             app(WhatsAppService::class)->send($order->customer_phone, $message);
         } catch (\Exception $e) {
@@ -159,7 +159,7 @@ class OrderController extends Controller
                 $message .= "🔑 Password: `{$password}`\n\n";
                 $message .= "📦 Paket: {$order->package->name}\n";
                 $message .= "⚡ Kecepatan: {$order->package->speed}\n\n";
-                $message .= "Terima kasih telah berlangganan!\n*" . config('app.name') . "*";
+                $message .= "Terima kasih telah berlangganan!\n*" . companyName() . "*";
 
                 app(WhatsAppService::class)->send($customer->phone, $message);
             } catch (\Exception $e) {
@@ -182,14 +182,15 @@ class OrderController extends Controller
 
     protected function notifyCustomer(Order $order, $status)
     {
+        $company = companyName();
         $messages = [
-            'confirmed' => "✅ *Pesanan Dikonfirmasi*\n\nHalo *{$order->customer_name}*,\n\nPesanan Anda *{$order->order_number}* telah dikonfirmasi.\n\nKami akan segera menghubungi Anda untuk jadwal pemasangan.\n\n*" . config('app.name') . "*",
+            'confirmed' => "✅ *Pesanan Dikonfirmasi*\n\nHalo *{$order->customer_name}*,\n\nPesanan Anda *{$order->order_number}* telah dikonfirmasi.\n\nKami akan segera menghubungi Anda untuk jadwal pemasangan.\n\n*{$company}*",
             
-            'scheduled' => "📅 *Jadwal Pemasangan*\n\nHalo *{$order->customer_name}*,\n\nPemasangan dijadwalkan:\n📅 Tanggal: " . ($order->installation_date ? $order->installation_date->format('d M Y') : '-') . "\n⏰ Waktu: {$order->installation_time}\n\nTeknisi kami akan menghubungi Anda.\n\n*" . config('app.name') . "*",
+            'scheduled' => "📅 *Jadwal Pemasangan*\n\nHalo *{$order->customer_name}*,\n\nPemasangan dijadwalkan:\n📅 Tanggal: " . ($order->installation_date ? $order->installation_date->format('d M Y') : '-') . "\n⏰ Waktu: {$order->installation_time}\n\nTeknisi kami akan menghubungi Anda.\n\n*{$company}*",
             
-            'installing' => "🔧 *Pemasangan Dimulai*\n\nHalo *{$order->customer_name}*,\n\nTeknisi kami sedang dalam perjalanan untuk melakukan pemasangan.\n\n*" . config('app.name') . "*",
+            'installing' => "🔧 *Pemasangan Dimulai*\n\nHalo *{$order->customer_name}*,\n\nTeknisi kami sedang dalam perjalanan untuk melakukan pemasangan.\n\n*{$company}*",
             
-            'cancelled' => "❌ *Pesanan Dibatalkan*\n\nHalo *{$order->customer_name}*,\n\nPesanan *{$order->order_number}* telah dibatalkan.\n\nJika ada pertanyaan, silakan hubungi kami.\n\n*" . config('app.name') . "*",
+            'cancelled' => "❌ *Pesanan Dibatalkan*\n\nHalo *{$order->customer_name}*,\n\nPesanan *{$order->order_number}* telah dibatalkan.\n\nJika ada pertanyaan, silakan hubungi kami.\n\n*{$company}*",
         ];
 
         if (isset($messages[$status])) {

--- a/app/Http/Controllers/Admin/PaymentController.php
+++ b/app/Http/Controllers/Admin/PaymentController.php
@@ -149,7 +149,7 @@ class PaymentController extends Controller
         $message .= "🔗 *Link Pembayaran:*\n{$result['payment_url']}\n\n";
         $message .= "Link ini berlaku selama 24 jam.\n\n";
         $message .= "Terima kasih,\n";
-        $message .= "*" . config('app.name') . "*";
+        $message .= "*" . companyName() . "*";
 
         $waResult = $this->whatsapp->send($customer->phone, $message);
 

--- a/app/Services/WhatsAppService.php
+++ b/app/Services/WhatsAppService.php
@@ -79,7 +79,7 @@ class WhatsAppService
         $message .= "📅 *Jatuh Tempo:* " . ($invoice->due_date ? $invoice->due_date->format('d M Y') : '-') . "\n\n";
         $message .= "Silakan lakukan pembayaran sebelum jatuh tempo.\n\n";
         $message .= "Terima kasih,\n";
-        $message .= "*" . config('app.name') . "*";
+        $message .= "*" . companyName() . "*";
 
         $result = $this->send($customer->phone, $message);
         $this->logMessage($customer->phone, 'invoice', $message, $result, $customer->id, $invoice->id);
@@ -97,7 +97,7 @@ class WhatsAppService
         $message .= "💰 *Jumlah:* Rp " . number_format($invoice->amount, 0, ',', '.') . "\n";
         $message .= "📅 *Tanggal Bayar:* " . ($invoice->paid_date ? $invoice->paid_date->format('d M Y') : now()->format('d M Y')) . "\n\n";
         $message .= "Terima kasih atas pembayaran Anda.\n\n";
-        $message .= "*" . config('app.name') . "*";
+        $message .= "*" . companyName() . "*";
 
         return $this->send($customer->phone, $message);
     }
@@ -121,7 +121,7 @@ class WhatsAppService
         $message .= "2. Buka browser\n";
         $message .= "3. Masukkan username & password\n\n";
         $message .= "Terima kasih!\n";
-        $message .= "*" . config('app.name') . "*";
+        $message .= "*" . companyName() . "*";
 
         return $this->send($phone, $message);
     }
@@ -138,7 +138,7 @@ class WhatsAppService
         $message .= "💰 *Total:* Rp " . number_format($invoice->amount, 0, ',', '.') . "\n";
         $message .= "📅 *Jatuh Tempo:* " . ($invoice->due_date ? $invoice->due_date->format('d M Y') : '-') . "\n\n";
         $message .= "Mohon segera lakukan pembayaran untuk menghindari pemutusan layanan.\n\n";
-        $message .= "*" . config('app.name') . "*";
+        $message .= "*" . companyName() . "*";
 
         $result = $this->send($customer->phone, $message);
         $this->logMessage($customer->phone, 'reminder', $message, $result, $customer->id, $invoice->id);
@@ -154,7 +154,7 @@ class WhatsAppService
         $message .= "Halo *{$customer->name}*,\n\n";
         $message .= "Layanan internet Anda telah ditangguhkan karena tunggakan pembayaran.\n\n";
         $message .= "Silakan hubungi kami atau lakukan pembayaran untuk mengaktifkan kembali layanan Anda.\n\n";
-        $message .= "*" . config('app.name') . "*";
+        $message .= "*" . companyName() . "*";
 
         $result = $this->send($customer->phone, $message);
         $this->logMessage($customer->phone, 'suspension', $message, $result, $customer->id);

--- a/resources/views/admin/whatsapp/test.blade.php
+++ b/resources/views/admin/whatsapp/test.blade.php
@@ -127,7 +127,7 @@ Tagihan internet Anda telah terbit:
 Silakan lakukan pembayaran sebelum jatuh tempo.
 
 Terima kasih,
-*{{ config('app.name') }}*</pre>
+*{{ companyName() }}*</pre>
                             </div>
 
                             <!-- Reminder Template -->
@@ -144,7 +144,7 @@ Tagihan Anda belum dibayar:
 
 Mohon segera lakukan pembayaran untuk menghindari pemutusan layanan.
 
-*{{ config('app.name') }}*</pre>
+*{{ companyName() }}*</pre>
                             </div>
 
                             <!-- Suspension Template -->
@@ -157,7 +157,7 @@ Layanan internet Anda telah ditangguhkan karena tunggakan pembayaran.
 
 Silakan hubungi kami atau lakukan pembayaran untuk mengaktifkan kembali layanan Anda.
 
-*{{ config('app.name') }}*</pre>
+*{{ companyName() }}*</pre>
                             </div>
 
                             <!-- Custom Template -->

--- a/resources/views/order/create.blade.php
+++ b/resources/views/order/create.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Order {{ $package->name }} - {{ config('app.name') }}</title>
+    <title>Order {{ $package->name }} - {{ companyName() }}</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
@@ -13,7 +13,7 @@
         <div class="container mx-auto px-4">
             <a href="{{ url('/') }}" class="flex items-center space-x-2">
                 <i class="fas fa-wifi text-2xl text-cyan-400"></i>
-                <span class="text-xl font-bold">{{ config('app.name') }}</span>
+                <span class="text-xl font-bold">{{ companyName() }}</span>
             </a>
         </div>
     </div>

--- a/resources/views/order/success.blade.php
+++ b/resources/views/order/success.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pesanan Berhasil - {{ config('app.name') }}</title>
+    <title>Pesanan Berhasil - {{ companyName() }}</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
@@ -54,7 +54,7 @@
                     <div class="bg-white rounded p-3 text-sm">
                         <p><strong>Bank BCA</strong></p>
                         <p>No. Rek: 1234567890</p>
-                        <p>A/N: {{ config('app.name') }}</p>
+                        <p>A/N: {{ companyName() }}</p>
                         <p class="mt-2 font-bold">Jumlah: Rp {{ number_format($order->total_amount, 0, ',', '.') }}</p>
                     </div>
                     <p class="text-xs text-yellow-600 mt-2">

--- a/resources/views/order/track.blade.php
+++ b/resources/views/order/track.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Lacak Pesanan - {{ config('app.name') }}</title>
+    <title>Lacak Pesanan - {{ companyName() }}</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
@@ -12,7 +12,7 @@
         <div class="container mx-auto px-4">
             <a href="{{ url('/') }}" class="flex items-center space-x-2">
                 <i class="fas fa-wifi text-2xl text-cyan-400"></i>
-                <span class="text-xl font-bold">{{ config('app.name') }}</span>
+                <span class="text-xl font-bold">{{ companyName() }}</span>
             </a>
         </div>
     </div>

--- a/resources/views/payment/failed.blade.php
+++ b/resources/views/payment/failed.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pembayaran Gagal - {{ config('app.name') }}</title>
+    <title>Pembayaran Gagal - {{ companyName() }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <style>

--- a/resources/views/payment/success.blade.php
+++ b/resources/views/payment/success.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pembayaran Berhasil - {{ config('app.name') }}</title>
+    <title>Pembayaran Berhasil - {{ companyName() }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <style>


### PR DESCRIPTION
- Update OrderController WhatsApp messages
- Update WhatsAppService all notification methods
- Update InvoiceController payment link message
- Update PaymentController payment link message
- Update ReactivatePaidCustomers command
- Update WhatsApp test view templates
- Update order views (create, success, track)
- Update payment views (success, failed)

All company name references now use dynamic companyName() from app_settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how company name is referenced throughout the application in customer notifications (invoices, payments, orders, reminders), customer-facing views (order tracking, payment status), and order management interfaces for improved consistency and flexibility in name management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->