### PR TITLE
feat: Add IP Monitor to scheduled tasks

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -67,3 +67,9 @@ Schedule::command('mikrotik:sync-users --update')
     ->hourly()
     ->withoutOverlapping()
     ->appendOutputTo(storage_path('logs/mikrotik.log'));
+
+// Check IP Monitors every 5 minutes
+Schedule::command('ip-monitor:check')
+    ->everyFiveMinutes()
+    ->withoutOverlapping()
+    ->appendOutputTo(storage_path('logs/ip-monitor.log'));


### PR DESCRIPTION
- Run ip-monitor:check every 5 minutes
- Log output to storage/logs/ip-monitor.log