### PR TITLE
ci: Remove parallel flag from test execution

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -221,7 +221,7 @@ jobs:
           DB_DATABASE: testing
           DB_USERNAME: root
           DB_PASSWORD: password
-        run: php artisan test --parallel
+        run: php artisan test
 
   # ============================================
   # Security Gate - All checks must pass


### PR DESCRIPTION
- Remove --parallel flag from php artisan test command
- Simplify test execution to run sequentially
- Improve test reliability and reduce potential race conditions in CI environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated CI/CD workflow to execute tests serially instead of in parallel during the testing phase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->